### PR TITLE
Fix compatibility with veil

### DIFF
--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/render/MixinLevelRenderer.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/render/MixinLevelRenderer.java
@@ -69,7 +69,7 @@ public abstract class MixinLevelRenderer {
 
 	@Redirect(method = "renderLevel",
 		slice = @Slice(from = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/LevelRenderer;particlesTarget:Lcom/mojang/blaze3d/pipeline/RenderTarget;")),
-		at = @At(value = "INVOKE", ordinal = 0, target = "Lcom/mojang/blaze3d/pipeline/RenderTarget;clear(Z)V"))
+		at = @At(value = "INVOKE", ordinal = 0, target = "Lcom/mojang/blaze3d/pipeline/RenderTarget;clear(Z)V"), require = 0)
 	private void redirectClearRenderTarget(RenderTarget instance, boolean bl) {
 		// no-op
 	}


### PR DESCRIPTION
Don't crash if veil is already redirecting `Lcom/mojang/blaze3d/pipeline/RenderTarget;clear(Z)`

[relevant mixin](https://github.com/FoundryMC/Veil/blob/853487016986f664a8b39b007c960e4dbe7fc016/common/src/main/java/foundry/veil/mixin/performance/client/PerformanceLevelRendererMixin.java#L23-L27)