### PR TITLE
将异步渲染粒子的功能默认禁用

### DIFF
--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/AsyncRenderer.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/AsyncRenderer.java
@@ -116,7 +116,7 @@ public class AsyncRenderer {
 
 	/* Renderer */
 
-	public static void start(float f, Camera camera, int irm) {
+	public static void start(float partialTick, Camera camera, int irm) {
 		tryDebug();
 		switch (irm) {
 			case MIXED_SYNC, BEFORE_SYNC -> {
@@ -152,22 +152,23 @@ public class AsyncRenderer {
 			if (bufferBuilder == FakeBufferBuilder.INSTANCE) {
 				continue;
 			}
-			asyncTasks.add(CompletableFuture.runAsync(() -> renderParticles(f, camera, queue, particleRenderType, bufferBuilder), EXECUTOR)
-				.exceptionally(AsyncRenderer::renderAsyncExceptionally));
+			// asyncTasks.add(CompletableFuture.runAsync(() -> renderParticles(partialTick, camera, queue, particleRenderType, bufferBuilder), EXECUTOR)
+			//	 .exceptionally(AsyncRenderer::renderAsyncExceptionally));
+			renderParticles(partialTick, camera, queue, particleRenderType, bufferBuilder);
 		}
 		int size = asyncTasksSize = asyncTasks.size();
 		asyncTask = CompletableFuture.allOf(asyncTasks.toArray(new CompletableFuture[size]));
 		profiler.pop();
 	}
 
-	private static void renderParticles(float f,
+	private static void renderParticles(float partialTick,
 										Camera camera,
 										Queue<Particle> particles,
 										ParticleRenderType particleRenderType,
 										BufferBuilder bufferBuilder) {
 		Frustum frustum = AsyncRenderer.frustum;
 		ParticleCullingMode particleCullingMode = ConfigHelper.getParticleCullingMode();
-		float f2 = f + 1f;
+		float f2 = partialTick + 1f;
 		for (Particle particle : particles) {
 			if (!particle.isAlive()) {
 				continue;
@@ -196,7 +197,7 @@ public class AsyncRenderer {
 				recordSync(particleRenderType, particle);
 				continue;
 			}
-			float f3 = particleAddon.asyncparticles$isTicked() ? f : f2;
+			float f3 = particleAddon.asyncparticles$isTicked() ? partialTick : f2;
 			try {
 				particle.render(bufferBuilder, camera, f3);
 			} catch (Throwable t) {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     modLocalRuntime 'thedarkcolour:kotlinforforge:4.10.0'
     modLocalRuntime "maven.modrinth:valkyrien-skies:1.20.1-forge-2.3.0-beta.9"
     modCompileOnly "maven.modrinth:valkyrien-skies:1.20.1-forge-2.3.0-beta.9"
-    modLocalRuntime 'maven.modrinth:eureka:1.20.1-forge-1.5.1-beta.3'
+    //modLocalRuntime 'maven.modrinth:eureka:1.20.1-forge-1.5.1-beta.3'
 
     /* Particle Rain/Pretty Rain */
     modCompileOnly "maven.modrinth:pretty-rain:yIvOKPKZ" // 1.1.3
@@ -124,19 +124,19 @@ dependencies {
 //    modLocalRuntime("com.github.Fallen-Breath.conditional-mixin:conditional-mixin-forge:0.6.2")
     /* Epic Fight */
     modCompileOnly "maven.modrinth:epic-fight:20.12.5"
-    modLocalRuntime "maven.modrinth:epic-fight:20.12.5"
+    //modLocalRuntime "maven.modrinth:epic-fight:20.12.5"
 
     /* Gateways to Eternity */
     modCompileOnly "curse.maven:gateway-to-eternity-417802:5703251"
-    modLocalRuntime "curse.maven:gateway-to-eternity-417802:5703251"
+    //modLocalRuntime "curse.maven:gateway-to-eternity-417802:5703251"
 
     /* Epic ACG */
     modCompileOnly "curse.maven:epic-acg-665625:6106647"
-    modLocalRuntime "curse.maven:epic-acg-665625:6106647"
+   // modLocalRuntime "curse.maven:epic-acg-665625:6106647"
 
     /* Draconic Evolution */
     modCompileOnly "maven.modrinth:draconic-evolution:3.1.2.604"
-    modLocalRuntime "maven.modrinth:draconic-evolution:3.1.2.604"
+    //modLocalRuntime "maven.modrinth:draconic-evolution:3.1.2.604"
 
     /* Iron's Spells and Spellbooks */
     modCompileOnly "maven.modrinth:irons-spells-n-spellbooks:1.20.1-3.4.0.7"
@@ -144,7 +144,7 @@ dependencies {
 
     /* Weather2 */
     modCompileOnly "curse.maven:weather2-237746:5244118" // 2.8.3
-    modLocalRuntime "curse.maven:weather2-237746:5244118" // 2.8.3
+    //modLocalRuntime "curse.maven:weather2-237746:5244118" // 2.8.3
 
     /* Aquaculture */
     modCompileOnly "maven.modrinth:aquamirae:7lX4KLFc"


### PR DESCRIPTION
一些群聊记录，如有需要可以提供完整上下文，当时对 tetra、asyncparticles、modernfix 的问题都进行了分析和讨论，这里只截取与您的模组相关的部分：

<img width="500px" alt="image" src="https://github.com/user-attachments/assets/fc878229-48d5-409f-a6c1-19d0579dec0b" />

<img width="500px" alt="image" src="https://github.com/user-attachments/assets/8a32ac8d-d780-43f7-8574-027bb9aac5bb" />

关于这个模组的设计，我和经常帮助 HMCL 和 PCL 社区其它几位提供无偿报错诊断的朋友 review 了一下，为了保证绝大多数模组兼容性，在最小化修改的前提下对模组进行了小小的效率牺牲。当然是否合并取决于您的想法，我们也只是收集玩家的崩溃反馈并向问题模组（如果开源）提交修复。

# 修改前：
<img width="1621" height="1045" alt="image" src="https://github.com/user-attachments/assets/4a1156db-c94d-423f-acd8-d8298c40e06b" />

# 修改后：
<img width="824" height="872" alt="image" src="https://github.com/user-attachments/assets/544836c2-0eea-48d3-8e40-95cfe14d6da0" />

This will fix #151, #149, #130, #103, #87 and some other issues.