### PR TITLE
Particle Interactions compat

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -94,4 +94,7 @@ dependencies {
 //    modCompileOnly "maven.modrinth:veil:ux6J2bdY" // 3.6.2
     /* Sable */
     modApi "dev.ryanhcode.sable:sable-common-$minecraft_version:1.1.3" // 1.1.3
+
+    /* Particle Interactions */
+    modCompileOnly "maven.modrinth:particle-interactions:0.4.1-patch.1"
 }

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/compat/ModListHelper.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/compat/ModListHelper.java
@@ -117,6 +117,8 @@ public class ModListHelper {
 	public static final boolean SABLE_LOADED = isModLoaded("sable");
 	/* Axiom */
 	public static final boolean AXIOM_LOADED = isModLoaded("axiom");
+	/* Particle Interactions */
+	public static final boolean PARTICLE_INTERACTIONS_LOADED = isModLoaded("eg_particle_interactions");
 
 	@ExpectPlatform
 	private static boolean isForge() {

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/coremod/AsyncParticlesMixinPlugin.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/coremod/AsyncParticlesMixinPlugin.java
@@ -110,6 +110,7 @@ public class AsyncParticlesMixinPlugin implements IMixinConfigPlugin {
 			case "immediatelyfast" -> IMMEDIATELY_FAST_LOADED;
 			case "figura" -> FIGURA_LOADED;
 			case "veil" -> VEIL_LOADED && versionCheck("veil", "1.999999", null);
+			case "particle_interactions" -> PARTICLE_INTERACTIONS_LOADED;
 			default -> throw new IllegalArgumentException("Unknown mixin: " + mixinClassName);
 		};
 	}

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/particle_interactions/MixinParticle_FixBlackDestroyParticle.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/particle_interactions/MixinParticle_FixBlackDestroyParticle.java
@@ -1,0 +1,31 @@
+package fun.qu_an.minecraft.asyncparticles.client.mixin.particle_interactions;
+
+import fun.qu_an.minecraft.asyncparticles.client.particle.GpuParticleBehavior;
+import games.enchanted.blockplaceparticles.particle.dust.FloatingDust;
+import games.enchanted.blockplaceparticles.particle.petal.FallingPetal;
+import fun.qu_an.minecraft.asyncparticles.client.addon.LightCachedParticleAddon;
+import fun.qu_an.minecraft.asyncparticles.client.mixin.core.particle.MixinParticle_LightCache;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(value = { FloatingDust.class, FallingPetal.class })
+public abstract class MixinParticle_FixBlackDestroyParticle extends MixinParticle_LightCache implements LightCachedParticleAddon {
+
+    @Unique
+    private boolean asyncparticles$isFirstRefresh = true;
+
+    @Override
+    public void asyncparticles$refresh() {
+        if (asyncparticles$isFirstRefresh) {
+            asyncparticles$isFirstRefresh = false;
+            Integer i = GpuParticleBehavior.INSTANCE.DESTROY_LIGHT_CACHE.get();
+            if (i != null) {
+                asyncparticles$setLight(i);
+            } else {
+                super.asyncparticles$refresh();
+            }
+        } else {
+            super.asyncparticles$refresh();
+        }
+    }
+}

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/particle_interactions/MixinSpawnParticles.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/particle_interactions/MixinSpawnParticles.java
@@ -1,0 +1,116 @@
+package fun.qu_an.minecraft.asyncparticles.client.mixin.particle_interactions;
+
+import fun.qu_an.minecraft.asyncparticles.client.particle.GpuParticleBehavior;
+import games.enchanted.blockplaceparticles.particle_spawning.SpawnParticles;
+import games.enchanted.blockplaceparticles.particle_spawning.override.BlockParticleOverride;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.DataLayer;
+import net.minecraft.world.level.lighting.LayerLightEventListener;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static org.joml.Math.max;
+
+@Mixin(SpawnParticles.class)
+public class MixinSpawnParticles {
+    @Inject(method = "spawnBlockBreakParticle", at = @At("HEAD"))
+    private static void spawnBlockBreakParticlePre(ClientLevel level, BlockState brokenBlockState, BlockPos brokenBlockPos, BlockParticleOverride particleOverride, CallbackInfo ci) {
+        int lightColor = asyncparticles$getLightColor(level, brokenBlockPos);
+        GpuParticleBehavior.INSTANCE.DESTROY_LIGHT_CACHE.set(lightColor);
+    }
+
+    @Inject(method = "spawnBlockBreakParticle", at = @At("RETURN"))
+    private static void spawnBlockBreakParticlePost(ClientLevel level, BlockState brokenBlockState, BlockPos brokenBlockPos, BlockParticleOverride particleOverride, CallbackInfo ci) {
+        GpuParticleBehavior.INSTANCE.DESTROY_LIGHT_CACHE.remove();
+    }
+
+    @Unique
+    private static int asyncparticles$getLightColor(ClientLevel level, BlockPos pos) {
+        var asyncparticles$mutable = new BlockPos.MutableBlockPos();
+        LayerLightEventListener sky = level.getLightEngine().getLayerListener(LightLayer.SKY);
+        LayerLightEventListener block = level.getLightEngine().getLayerListener(LightLayer.BLOCK);
+        int x = pos.getX();
+        int y = pos.getY();
+        int z = pos.getZ();
+        int lx = x & 15;
+        int ly = y & 15;
+        int lz = z & 15;
+        int i;
+        int j;
+
+        DataLayer skyDataLayerData = sky.getDataLayerData(SectionPos.of(pos));
+        if (skyDataLayerData == null) {
+            i = 16;
+        } else {
+            i = ly == 15 ? sky.getLightValue(asyncparticles$mutable.set(x, y + 1, z)) :
+                    skyDataLayerData.get(lx, ly + 1, lz);
+        }
+        DataLayer blockDataLayerData = block.getDataLayerData(SectionPos.of(pos));
+        if (blockDataLayerData == null) {
+            j = 16;
+        } else {
+            j = ly == 15 ? block.getLightValue(asyncparticles$mutable.set(x, y + 1, z)) :
+                    blockDataLayerData.get(lx, ly + 1, lz);
+        }
+
+        if (i < 15) {
+            i = max(i, lz == 0 ? sky.getLightValue(asyncparticles$mutable.set(x, y, z - 1)) :
+                    skyDataLayerData.get(lx, ly, lz - 1));
+        }
+        if (j < 15) {
+            j = max(j, lz == 0 ? block.getLightValue(asyncparticles$mutable.set(x, y, z - 1)) :
+                    blockDataLayerData.get(lx, ly, lz - 1));
+        }
+
+        if (i < 15) {
+            i = max(i, lx == 0 ? sky.getLightValue(asyncparticles$mutable.set(x - 1, y, z)) :
+                    skyDataLayerData.get(lx - 1, ly, lz));
+        }
+        if (j < 15) {
+            j = max(j, lx == 0 ? block.getLightValue(asyncparticles$mutable.set(x - 1, y, z)) :
+                    blockDataLayerData.get(lx - 1, ly, lz));
+        }
+
+        if (i < 15) {
+            i = max(i, lz == 15 ? sky.getLightValue(asyncparticles$mutable.set(x, y, z + 1)) :
+                    skyDataLayerData.get(lx, ly, lz + 1));
+        }
+        if (j < 15) {
+            j = max(j, lz == 15 ? block.getLightValue(asyncparticles$mutable.set(x, y, z + 1)) :
+                    blockDataLayerData.get(lx, ly, lz + 1));
+        }
+
+        if (i < 15) {
+            i = max(i, lx == 15 ? sky.getLightValue(asyncparticles$mutable.set(x + 1, y, z)) :
+                    skyDataLayerData.get(lx + 1, ly, lz));
+        }
+        if (j < 15) {
+            j = max(j, lx == 15 ? block.getLightValue(asyncparticles$mutable.set(x + 1, y, z)) :
+                    blockDataLayerData.get(lx + 1, ly, lz));
+        }
+
+        if (i < 15) {
+            i = max(i, ly == 0 ? sky.getLightValue(asyncparticles$mutable.set(x, y - 1, z)) :
+                    skyDataLayerData.get(lx, ly - 1, lz));
+        }
+        if (j < 15) {
+            j = max(j, ly == 0 ? block.getLightValue(asyncparticles$mutable.set(x, y - 1, z)) :
+                    blockDataLayerData.get(lx, ly - 1, lz));
+        }
+
+        if (i < 15 && i > 0) {
+            --i;
+        }
+        if (j > 0) {
+            --j;
+        }
+        return (i & 0xF) << 20 | (j & 0xF) << 4;
+    }
+}

--- a/common/src/main/resources/asyncparticles-common.mixins.json
+++ b/common/src/main/resources/asyncparticles-common.mixins.json
@@ -65,6 +65,8 @@
     "lodestone.MixinLodestoneRenderLayer",
     "lodestone.MixinRenderHandler",
     "modernui.MixinRenderSystem",
+    "particle_interactions.MixinParticle_FixBlackDestroyParticle",
+    "particle_interactions.MixinSpawnParticles",
     "physicsmod.MixinClientLevel",
     "physicsmod.MixinLevelRenderer",
     "physicsmod.MixinRainParticle",


### PR DESCRIPTION
Fixes the black destruction particles

I tried to adhere to your conventions as best as possible, let me know if I missed something.
Also `asyncparticles$getLightColor` is a duplicate from `fun.qu_an.minecraft.asyncparticles.client.mixin.core.particle.MixinParticleEngine_FixBlackDestroyParticle`, maybe this should be moved to another class?