### PR TITLE
Bare minimum 1.21.11 port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'dev.architectury.loom' version '1.11-SNAPSHOT' apply false
+    id 'dev.architectury.loom' version '1.13-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
     id "io.github.pacifistmc.forgix" version "1.2.9"

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -27,13 +27,13 @@ dependencies {
     modCompileOnly "maven.modrinth:fzzy-config:0.7.2+1.21.6"
 
     /* Performance */
-    modCompileOnly "maven.modrinth:sodium:mc1.21.10-0.7.2-fabric"
-    modCompileOnly "maven.modrinth:sodium-extra:mc1.21.9-0.7.0+fabric"
-    modCompileOnly 'maven.modrinth:iris:1.9.6+1.21.10-fabric'
-    modCompileOnly 'maven.modrinth:moreculling:nASRyMbu' // 1.5.0-beta.2
+    modCompileOnly "maven.modrinth:sodium:mc1.21.11-0.8.2-fabric"
+    modCompileOnly 'maven.modrinth:iris:1.10.4+1.21.11-fabric'
+    modCompileOnly 'maven.modrinth:sodium-extra:mc1.21.11-0.8.3+fabric'
+    modCompileOnly 'maven.modrinth:moreculling:kWU8mVq5' // 1.5.0-beta.2
 
     /* Particle Rain/Pretty Rain */
-    modCompileOnly "maven.modrinth:particle-rain:3.3.6"
+    modCompileOnly "maven.modrinth:particle-rain:v4-beta.5+1.21.11-fabric"
 
     /* Effectual */
     modCompileOnly 'maven.modrinth:effectual:1.1.0-1.21.8'

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ConfigHelper.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ConfigHelper.java
@@ -1,7 +1,7 @@
 package fun.qu_an.minecraft.asyncparticles.client.config;
 
 import fun.qu_an.minecraft.asyncparticles.client.compat.ModListHelper;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 
 import java.util.Set;
 
@@ -81,7 +81,7 @@ public class ConfigHelper {
 	}
 
 	// TODO: implement weather particle config, which will not be spawn into physics structures
-	public static Set<ResourceLocation> getWeatherParticles() {
+	public static Set<Identifier> getWeatherParticles() {
 		return Set.of();
 	}
 

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/GameUtil.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/GameUtil.java
@@ -3,7 +3,7 @@ package fun.qu_an.minecraft.asyncparticles.client.core;
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import fun.qu_an.minecraft.asyncparticles.client.AsyncParticlesClient;
 import net.minecraft.ReportedException;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.world.phys.AABB;
 
 public class GameUtil {
@@ -12,8 +12,8 @@ public class GameUtil {
 		throw new AssertionError();
 	}
 
-	public static ResourceLocation id(String path) {
-		return ResourceLocation.fromNamespaceAndPath(AsyncParticlesClient.MOD_ID, path);
+	public static Identifier id(String path) {
+		return Identifier.fromNamespaceAndPath(AsyncParticlesClient.MOD_ID, path);
 	}
 
 	public static ReportedException getReportedException(Throwable t) {

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_render/AsyncQuadParticleRenderState.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_render/AsyncQuadParticleRenderState.java
@@ -19,6 +19,7 @@ import net.minecraft.client.renderer.state.QuadParticleRenderState;
 import net.minecraft.util.ARGB;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Matrix4f;
 import org.joml.Quaternionf;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
@@ -245,8 +246,7 @@ public class AsyncQuadParticleRenderState extends QuadParticleRenderState implem
 					RenderSystem.getModelViewMatrix(),
 					new Vector4f(1.0F, 1.0F, 1.0F, 1.0F),
 					new Vector3f(),
-					RenderSystem.getTextureMatrix(),
-					RenderSystem.getShaderLineWidth()
+						new Matrix4f()
 				);
 			return new PreparedBuffers(meshData.drawState().indexCount(), gpuBufferSlice, preparedLayers);
 

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_render/AsyncRenderBehavior.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_render/AsyncRenderBehavior.java
@@ -6,7 +6,7 @@ import fun.qu_an.minecraft.asyncparticles.client.util.ExceptionUtil;
 import net.minecraft.CrashReport;
 import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportedException;
-import net.minecraft.Util;
+import net.minecraft.util.Util;
 import net.minecraft.util.Mth;
 import net.minecraft.world.level.chunk.MissingPaletteEntryException;
 import org.jetbrains.annotations.NotNull;

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_tick/AsyncTickBehavior.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/async_tick/AsyncTickBehavior.java
@@ -11,7 +11,7 @@ import fun.qu_an.minecraft.asyncparticles.client.util.ThreadUtil;
 import net.minecraft.CrashReport;
 import net.minecraft.CrashReportCategory;
 import net.minecraft.ReportedException;
-import net.minecraft.Util;
+import net.minecraft.util.Util;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.particle.*;
 import net.minecraft.util.Mth;

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/conditional/MixinAsyncTick_ModifyTheFromParticleMethod.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/conditional/MixinAsyncTick_ModifyTheFromParticleMethod.java
@@ -16,10 +16,11 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin({
 	ItemPickupParticleGroup.class,
-	ElderGuardianParticleGroup.class
+	ElderGuardianParticleGroup.class/*ItemPickupParticleGroup.ParticleInstance.class,
+	ElderGuardianParticleGroup.ElderGuardianParticleRenderState.class*/
 })
 public class MixinAsyncTick_ModifyTheFromParticleMethod {
-	@Dynamic
+	/*@Dynamic
 	@Inject(method = "*", at = @At("HEAD"))
 	private static void modifyParticleRecord(@Coerce Particle particle,
 											 Camera camera,
@@ -28,5 +29,5 @@ public class MixinAsyncTick_ModifyTheFromParticleMethod {
 											 @Local(ordinal = 0, argsOnly = true) LocalFloatRef tickDelta) {
 		float v = !((ParticleAddon) particle).asyncparticles$isTicked() && f <= 1.0f ? f + 1.0f : f;
 		tickDelta.set(v);
-	}
+	}*/
 }

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/conditional/MixinClassInstanceMultiMap.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/conditional/MixinClassInstanceMultiMap.java
@@ -43,7 +43,7 @@ public class MixinClassInstanceMultiMap {
 	// FIXME: can't remap lambda method_15217 properly, use * instead
 	@Dynamic
 	@Group(name = "redirect_collector", min = 1)
-	@Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/Util;toMutableList()Ljava/util/stream/Collector;"))
+	@Redirect(method = "*", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/Util;toMutableList()Ljava/util/stream/Collector;"))
 	private <T> Collector<T, ?, List<T>> collect1() {
 		return Collectors.toCollection(IterationSafeArrayList::new);
 	}

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/particle/async_render/MixinLevelRenderer.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/particle/async_render/MixinLevelRenderer.java
@@ -51,7 +51,7 @@ public abstract class MixinLevelRenderer {
 								 boolean bl2,
 								 CallbackInfo ci,
 								 @Share("earlyFrustum") LocalRef<Frustum> frustumRef) {
-		Frustum frustum = prepareCullFrustum(matrix4f, matrix4f3, camera.getPosition());
+		Frustum frustum = prepareCullFrustum(matrix4f, matrix4f3, camera.position());
 		frustumRef.set(frustum);
 		if (asyncparticles$extractParticles != null) {
 			asyncparticles$extractParticles.call(Minecraft.getInstance().particleEngine,

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/off_thread_access/MixinSoundEngine.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/off_thread_access/MixinSoundEngine.java
@@ -9,7 +9,7 @@ import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.client.resources.sounds.TickableSoundInstance;
 import net.minecraft.client.sounds.SoundEngine;
 import net.minecraft.client.sounds.SoundEventListener;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundSource;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
@@ -41,7 +41,7 @@ public abstract class MixinSoundEngine {
 	public abstract void destroy();
 
 	@Shadow
-	public abstract void updateCategoryVolume(SoundSource soundSource);
+	public abstract void refreshCategoryVolume(SoundSource soundSource);
 
 	@Shadow
 	public abstract SoundEngine.PlayResult play(SoundInstance soundInstance);
@@ -62,13 +62,13 @@ public abstract class MixinSoundEngine {
 	public abstract void playDelayed(SoundInstance soundInstance, int i);
 
 	@Shadow
-	public abstract void stop(@Nullable ResourceLocation resourceLocation, @Nullable SoundSource soundSource);
+	public abstract void stop(@Nullable Identifier resourceLocation, @Nullable SoundSource soundSource);
 
 	@Shadow
 	public abstract void stop(SoundInstance soundInstance);
 
 	@Shadow
-	public abstract void setVolume(SoundInstance soundInstance, float f);
+	public abstract float calculateVolume(float f, SoundSource soundSource);
 
 	@Shadow
 	public abstract void pauseAllExcept(SoundSource... soundSources);
@@ -113,11 +113,11 @@ public abstract class MixinSoundEngine {
 		}
 	}
 
-	@Inject(method = "updateCategoryVolume", at = @At("HEAD"), cancellable = true)
+	@Inject(method = "refreshCategoryVolume", at = @At("HEAD"), cancellable = true)
 	public void injectUpdateCategoryVolume(SoundSource soundSource, CallbackInfo ci) {
 		if (ThreadUtil.isOnParticleThread()) {
 			ci.cancel();
-			ThreadUtil.enqueueClientTask(() -> this.updateCategoryVolume(soundSource));
+			ThreadUtil.enqueueClientTask(() -> this.refreshCategoryVolume(soundSource));
 		}
 	}
 
@@ -175,8 +175,8 @@ public abstract class MixinSoundEngine {
 		}
 	}
 
-	@Inject(method = "stop(Lnet/minecraft/resources/ResourceLocation;Lnet/minecraft/sounds/SoundSource;)V", at = @At("HEAD"), cancellable = true)
-	public void injectStop(ResourceLocation soundName, SoundSource category, CallbackInfo ci) {
+	@Inject(method = "stop(Lnet/minecraft/resources/Identifier;Lnet/minecraft/sounds/SoundSource;)V", at = @At("HEAD"), cancellable = true)
+	public void injectStop(Identifier soundName, SoundSource category, CallbackInfo ci) {
 		if (ThreadUtil.isOnParticleThread()) {
 			ci.cancel();
 			ThreadUtil.enqueueClientTask(() -> this.stop(soundName, category));
@@ -191,11 +191,11 @@ public abstract class MixinSoundEngine {
 		}
 	}
 
-	@Inject(method = "setVolume", at = @At("HEAD"), cancellable = true)
-	public void injectSetVolume(SoundInstance soundInstance, float f, CallbackInfo ci) {
+	@Inject(method = "calculateVolume(FLnet/minecraft/sounds/SoundSource;)F", at = @At("HEAD"), cancellable = true)
+	public void injectSetVolume(float f, SoundSource soundSource, CallbackInfoReturnable<Float> cir) {
 		if (ThreadUtil.isOnParticleThread()) {
-			ci.cancel();
-			ThreadUtil.enqueueClientTask(() -> this.setVolume(soundInstance, f));
+			cir.cancel();
+			ThreadUtil.enqueueClientTask(() -> this.calculateVolume(f, soundSource));
 		}
 	}
 

--- a/common/src/main/resources/asyncparticles-common.accesswidener
+++ b/common/src/main/resources/asyncparticles-common.accesswidener
@@ -9,8 +9,8 @@ accessible field net/minecraft/util/thread/BlockableEventLoop pendingRunnables L
 transitive-mutable field net/minecraft/world/level/chunk/ChunkAccess blockEntities Ljava/util/Map;
 transitive-mutable field net/minecraft/world/level/chunk/ChunkAccess pendingBlockEntities Ljava/util/Map;
 accessible field com/mojang/blaze3d/opengl/GlBuffer handle I
-accessible method com/mojang/blaze3d/opengl/DirectStateAccess mapBufferRange (IIIII)Ljava/nio/ByteBuffer;
-accessible method com/mojang/blaze3d/opengl/DirectStateAccess flushMappedBufferRange (IIII)V
+accessible method com/mojang/blaze3d/opengl/DirectStateAccess mapBufferRange (IJJII)Ljava/nio/ByteBuffer;
+accessible method com/mojang/blaze3d/opengl/DirectStateAccess  flushMappedBufferRange (IJJI)V
 accessible method com/mojang/blaze3d/opengl/DirectStateAccess unmapBuffer (II)V
 accessible class com/mojang/blaze3d/opengl/GlBuffer$GlMappedView
 accessible method com/mojang/blaze3d/opengl/GlBuffer$GlMappedView <init> (Ljava/lang/Runnable;Lcom/mojang/blaze3d/opengl/GlBuffer;Ljava/nio/ByteBuffer;)V
@@ -23,7 +23,7 @@ accessible field net/minecraft/client/particle/QuadParticleGroup particleType Ln
 accessible field net/minecraft/client/particle/Particle x D
 accessible field net/minecraft/client/particle/Particle y D
 accessible field net/minecraft/client/particle/Particle z D
-accessible method net/minecraft/Util onThreadException (Ljava/lang/Thread;Ljava/lang/Throwable;)V
+accessible method net/minecraft/util/Util onThreadException (Ljava/lang/Thread;Ljava/lang/Throwable;)V
 accessible method net/minecraft/client/renderer/state/QuadParticleRenderState$Storage <init> ()V
 accessible method net/minecraft/client/particle/ParticleEngine updateCount (Lnet/minecraft/core/particles/ParticleLimit;I)V
 accessible field net/minecraft/client/particle/ParticleEngine particles Ljava/util/Map;

--- a/common/src/main/resources/asyncparticles-common.mixins.json
+++ b/common/src/main/resources/asyncparticles-common.mixins.json
@@ -6,6 +6,7 @@
   },
   "package": "fun.qu_an.minecraft.asyncparticles.client.mixin",
   "compatibilityLevel": "JAVA_17",
+  "refmap": "asyncparticles-common-refmap.json",
   "plugin": "fun.qu_an.minecraft.asyncparticles.client.coremod.AsyncParticlesMixinPlugin",
   "client": [
     "compat.sodium_extra.MixinFireworkParticles$Starter",

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -51,28 +51,28 @@ dependencies {
 //    modLocalRuntime("io.wispforest:owo-lib:0.12.21+1.21.6") {
 //        exclude(group: "net.fabricmc.fabric-api")
 //    }
-    modCompileOnly 'maven.modrinth:modmenu:16.0.0-rc.1'
-    modLocalRuntime 'maven.modrinth:modmenu:16.0.0-rc.1'
-    modLocalRuntime 'maven.modrinth:fabric-permissions-api:0.4.0'
+    modCompileOnly 'maven.modrinth:modmenu:17.0.0-beta.2'
+    modLocalRuntime 'maven.modrinth:modmenu:17.0.0-beta.2'
+    modLocalRuntime 'maven.modrinth:fabric-permissions-api:0.6.1'
     modLocalRuntime("me.fallenbreath:conditional-mixin-fabric:0.6.4")
 
     /* Performance */
-    modCompileOnly "maven.modrinth:sodium:mc1.21.10-0.7.2-fabric"
-    modCompileOnly 'maven.modrinth:iris:1.9.6+1.21.10-fabric'
-    modCompileOnly 'maven.modrinth:sodium-extra:mc1.21.9-0.7.0+fabric'
-    modLocalRuntime "maven.modrinth:sodium:mc1.21.10-0.7.2-fabric"
-    modLocalRuntime 'maven.modrinth:sodium-extra:mc1.21.9-0.7.0+fabric'
-    modLocalRuntime 'maven.modrinth:iris:1.9.6+1.21.10-fabric'
+    modCompileOnly "maven.modrinth:sodium:mc1.21.11-0.8.2-fabric"
+    modCompileOnly 'maven.modrinth:iris:1.10.4+1.21.11-fabric'
+    modCompileOnly 'maven.modrinth:sodium-extra:mc1.21.11-0.8.3+fabric'
+    modLocalRuntime "maven.modrinth:sodium:mc1.21.11-0.8.2-fabric"
+    modLocalRuntime 'maven.modrinth:sodium-extra:mc1.21.11-0.8.3+fabric'
+    modLocalRuntime 'maven.modrinth:iris:1.10.4+1.21.11-fabric'
     localRuntime "org.antlr:antlr4-runtime:4.13.1"
     localRuntime "io.github.douira:glsl-transformer:3.0.0-pre3"
     localRuntime "org.anarres:jcpp:1.4.14"
     modLocalRuntime 'maven.modrinth:scalablelux:0.1.6+fabric.c25518a'
-    modLocalRuntime 'maven.modrinth:spark:1.10.145-fabric'
-    modCompileOnly 'maven.modrinth:moreculling:ESxkwc6w' // 1.4.0-beta.1
+    modLocalRuntime 'maven.modrinth:spark:1.10.156-fabric'
+    modCompileOnly 'maven.modrinth:moreculling:kWU8mVq5' // 1.4.0-beta.1
 //    modLocalRuntime 'maven.modrinth:moreculling:ESxkwc6w' // 1.4.0-beta.1
 
     /* Particle Rain/Pretty Rain */
-    modCompileOnly "maven.modrinth:particle-rain:3.3.6"
+    modCompileOnly "maven.modrinth:particle-rain:v4-beta.5+1.21.11-fabric"
 //    modLocalRuntime "maven.modrinth:particle-rain:3.3.6"
 //    modLocalRuntime("dev.isxander:yet-another-config-lib:3.7.1+1.21.6-fabric"){
 //        exclude(group: "net.fabricmc.fabric-api")
@@ -117,6 +117,10 @@ dependencies {
 
     /* Immediately Fast */
     modCompileOnly "maven.modrinth:immediatelyfast:1.11.0+1.21.7-fabric"
+
+    // /polytone/version/1.21.11-5.3.0-fabric
+    modCompileOnly "maven.modrinth:polytone:1.21.11-5.3.0-fabric"
+    modLocalRuntime "maven.modrinth:polytone:1.21.11-5.3.0-fabric"
 }
 
 processResources {

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -117,10 +117,6 @@ dependencies {
 
     /* Immediately Fast */
     modCompileOnly "maven.modrinth:immediatelyfast:1.11.0+1.21.7-fabric"
-
-    // /polytone/version/1.21.11-5.3.0-fabric
-    modCompileOnly "maven.modrinth:polytone:1.21.11-5.3.0-fabric"
-    modLocalRuntime "maven.modrinth:polytone:1.21.11-5.3.0-fabric"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,17 +2,18 @@
 org.gradle.jvmargs=-Xmx4G
 org.gradle.parallel=true
 # Mod properties
-mod_version=0.7.1-alpha
+mod_version=0.7.2-alpha
 maven_group=fun.qu_an.minecraft
 archives_name=AsyncParticles-Lite
 enabled_platforms=fabric,neoforge
 # Minecraft properties
-minecraft_version=1.21.10
+minecraft_version=1.21.11
 # Dependencies
 # https://fabricmc.net/develop/
-fabric_loader_version=0.17.3
-fabric_api_version=0.135.0+1.21.10
+fabric_loader_version=0.18.4
+fabric_api_version=0.141.1+1.21.11
 # https://neoforged.net/
-neoforge_version=21.10.9-beta
+neoforge_version=21.11.35-beta
 
 snapshot=false
+loom.ignoreDependencyLoomVersionValidation=true


### PR DESCRIPTION
as per https://github.com/Harveykang/AsyncParticles/pull/168#issuecomment-4360658818

newer loom versions are probably fixed so `loom.ignoreDependencyLoomVersionValidation=true` can be removed ~~& the polytone dependency is a remnant from local experiments~~