### PR TITLE
Fix GPU particle corruption on macOS OpenGL

### DIFF
--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/DevRuntimeDebug.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/DevRuntimeDebug.java
@@ -31,6 +31,7 @@ public class DevRuntimeDebug {
 					case AUTO -> Backends.getGlTf(GL.getCapabilities());
 					case GL30 -> new GlCommands.TransformFeedback.GL30();
 					case ARB2 -> new GlCommands.TransformFeedback.ARB2();
+					case GL40 -> new GlCommands.TransformFeedback.GL40();
 					case GL45 -> new GlCommands.TransformFeedback.GL45();
 				};
 				Backends.gl = switch (directStateAccess) {
@@ -52,6 +53,7 @@ public class DevRuntimeDebug {
 		AUTO,
 		GL30,
 		ARB2,
+		GL40,
 		GL45
 	}
 }

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/backend/Backends.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/backend/Backends.java
@@ -79,6 +79,8 @@ public class Backends {
 	public static GlCommands.TransformFeedback getGlTf(GLCapabilities glCapabilities) {
 		if (glCapabilities.OpenGL45) {
 			return new GlCommands.TransformFeedback.GL45();
+		} else if (glCapabilities.OpenGL40) {
+			return new GlCommands.TransformFeedback.GL40();
 		} else if (glCapabilities.GL_ARB_transform_feedback2) {
 			return new GlCommands.TransformFeedback.ARB2();
 		} else if (glCapabilities.OpenGL30) {

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/backend/GlCommands.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/backend/GlCommands.java
@@ -334,6 +334,38 @@ public abstract class GlCommands {
 
 		public abstract void glTransformFeedbackVaryings(int tshProg, String[] varyings, int glInterleavedAttribs);
 
+		protected final void bindTransformFeedbackBufferBasePreservingState(int tf, int index, int buffer) {
+			int binding = GL11C.glGetInteger(GL40C.GL_TRANSFORM_FEEDBACK_BINDING);
+			int bufferBinding = GL11C.glGetInteger(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER_BINDING);
+			try {
+				if (binding != tf) {
+					glBindTransformFeedback(tf);
+				}
+				GL30C.glBindBufferBase(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer);
+			} finally {
+				if (binding != tf) {
+					glBindTransformFeedback(binding);
+				}
+				GL15C.glBindBuffer(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, bufferBinding);
+			}
+		}
+
+		protected final void bindTransformFeedbackBufferRangePreservingState(int tf, int index, int buffer, long offset, long size) {
+			int binding = GL11C.glGetInteger(GL40C.GL_TRANSFORM_FEEDBACK_BINDING);
+			int bufferBinding = GL11C.glGetInteger(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER_BINDING);
+			try {
+				if (binding != tf) {
+					glBindTransformFeedback(tf);
+				}
+				GL30C.glBindBufferRange(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer, offset, size);
+			} finally {
+				if (binding != tf) {
+					glBindTransformFeedback(binding);
+				}
+				GL15C.glBindBuffer(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, bufferBinding);
+			}
+		}
+
 		public String toString() {
 			return "TransformFeedback." + this.getClass().getSimpleName();
 		}
@@ -491,14 +523,7 @@ public abstract class GlCommands {
 				if (Backends.gl.directStateAccess()) {
 					ARBDirectStateAccess.glTransformFeedbackBufferBase(tf, index, buffer);
 				} else {
-					int binding = GL11C.glGetInteger(ARBTransformFeedback2.GL_TRANSFORM_FEEDBACK_BINDING);
-					if (binding == tf) {
-						GL30C.glBindBufferBase(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer);
-					} else {
-						glBindTransformFeedback(tf);
-						GL30C.glBindBufferBase(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer);
-						glBindTransformFeedback(binding);
-					}
+					bindTransformFeedbackBufferBasePreservingState(tf, index, buffer);
 				}
 			}
 
@@ -507,14 +532,7 @@ public abstract class GlCommands {
 				if (Backends.gl.directStateAccess()) {
 					ARBDirectStateAccess.glTransformFeedbackBufferRange(tf, index, buffer, offset, size);
 				} else {
-					int binding = GL11C.glGetInteger(ARBTransformFeedback2.GL_TRANSFORM_FEEDBACK_BINDING);
-					if (binding == tf) {
-						GL30C.glBindBufferRange(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer, offset, size);
-					} else {
-						glBindTransformFeedback(tf);
-						GL30C.glBindBufferRange(GL30C.GL_TRANSFORM_FEEDBACK_BUFFER, index, buffer, offset, size);
-						glBindTransformFeedback(binding);
-					}
+					bindTransformFeedbackBufferRangePreservingState(tf, index, buffer, offset, size);
 				}
 			}
 
@@ -534,7 +552,49 @@ public abstract class GlCommands {
 			}
 		}
 
-		public static class GL45 extends ARB2 {
+		public static class GL40 extends GL30 {
+			@Override
+			public boolean isTfObjectSupported() {
+				return true;
+			}
+
+			@Override
+			public int genTransformFeedback() {
+				return GL40C.glGenTransformFeedbacks();
+			}
+
+			@Override
+			public void deleteTransformFeedback(int tf) {
+				GL40C.glDeleteTransformFeedbacks(tf);
+			}
+
+			@Override
+			public void glBindTransformFeedbackBufferBase(int tf, int index, int buffer) {
+				bindTransformFeedbackBufferBasePreservingState(tf, index, buffer);
+			}
+
+			@Override
+			public void glBindTransformFeedbackBufferRange(int tf, int index, int buffer, long offset, long size) {
+				bindTransformFeedbackBufferRangePreservingState(tf, index, buffer, offset, size);
+			}
+
+			@Override
+			public void glBindTransformFeedback(int tf) {
+				GL40C.glBindTransformFeedback(GL40C.GL_TRANSFORM_FEEDBACK, tf);
+			}
+
+			@Override
+			public void glPauseTransformFeedback() {
+				GL40C.glPauseTransformFeedback();
+			}
+
+			@Override
+			public void glResumeTransformFeedback(int primitiveMode) {
+				GL40C.glResumeTransformFeedback();
+			}
+		}
+
+		public static class GL45 extends GL40 {
 			@Override
 			public int genTransformFeedback() {
 				return GL45C.glCreateTransformFeedbacks();

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/gpu_acceleration/opengl/ParticleVertexBuffer.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/gpu_acceleration/opengl/ParticleVertexBuffer.java
@@ -74,9 +74,7 @@ public class ParticleVertexBuffer {
 			offset, size,
 			GL30C.GL_MAP_WRITE_BIT |
 				(invalidateBufferBit ? GL30C.GL_MAP_INVALIDATE_BUFFER_BIT : 0) |
-				GL30C.GL_MAP_FLUSH_EXPLICIT_BIT |
-				GL30C.GL_MAP_UNSYNCHRONIZED_BIT |
-				0,
+				GL30C.GL_MAP_FLUSH_EXPLICIT_BIT,
 			this.mappedBuffer);
 		mapped = true;
 		mapOffset = offset;


### PR DESCRIPTION
## Summary

- stop mapping particle upload buffers with GL_MAP_UNSYNCHRONIZED_BIT
- restore the core OpenGL 4.0 transform-feedback backend for macOS/OpenGL 4.x contexts
- preserve both the transform-feedback object and generic buffer bindings while attaching buffers
- expose the GL40 backend in the existing developer selector

## Why

The unsynchronized mapping path allows the CPU to write a range that the GPU may still be consuming. OpenGL defines overlapping pending operations in that mode as undefined, which matches the corrupted particle vertices reported on macOS.

without fix
<img width="3456" height="2168" alt="image" src="https://github.com/user-attachments/assets/21bb7cac-6bf7-4e76-ba26-e0647a4e2ac2" />

with fix


The 26.1 branch already disabled that flag in [e0d5dc4](https://github.com/Harveykang/AsyncParticles/commit/e0d5dc4578100f70b947b35e89c92225efa8a7a4), but the corresponding 26.2 port [edc2833](https://github.com/Harveykang/AsyncParticles/commit/edc2833c38b504b85923c64c0f19d6cc3f0523ce) did not carry the safety change.

This also restores the core GL40 transform-feedback-object path that existed before the DSA refactor. Using an isolated transform-feedback object and restoring the generic buffer binding avoids leaking particle renderer state into the rest of the render pipeline.

Related to #232 and #236.

## Validation

- full Gradle build on Java 25, including Fabric, NeoForge, SPIR-V compilation, and the merged universal JAR
- hidden OpenGL 4.1 Metal context on an Apple M1 Max:
  - generated and bound core transform-feedback objects
  - attached the requested target buffer
  - verified the previous transform-feedback object and generic buffer bindings were restored
- git diff --check
- independent code review

Danger: AI slopped with GPT 5.6 Sol