### PR TITLE
Feature: Sync AnimateTick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ gradle-app.setting
 .gradletasknamecache
 
 **/build/
+**/bin/
 
 # Common working directory
 run/

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/AsyncParticlesConfig.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/AsyncParticlesConfig.java
@@ -58,6 +58,7 @@ public class AsyncParticlesConfig {
 	public static int tick$failPerSecLimit;
 	public static FailBehavior tick$failBehavior;
 	public static boolean tick$suppressCME;
+	public static Set<String> tick$syncAnimationClasses = new LinkedHashSet<>();
 	public static Set<String> tick$syncParticleClasses = new LinkedHashSet<>();
 	public static boolean rendering$gpuAcceleration;
 	public static boolean rendering$appendNewParticlesToRenderer;
@@ -238,6 +239,7 @@ public class AsyncParticlesConfig {
 
 	static ConfigObj getDefaultConfigExceptCollections() {
 		ConfigObj configObj = new ConfigObj();
+		configObj.tick.syncAnimationClasses = getCurrentConfig().tick.syncAnimationClasses;
 		configObj.tick.syncParticleClasses = getCurrentConfig().tick.syncParticleClasses;
 		return configObj;
 	}
@@ -326,6 +328,7 @@ public class AsyncParticlesConfig {
 			int failPerSecLimit = 5;
 			FailBehavior failBehavior = FailBehavior.RAISE_CRASH;
 			boolean suppressCME = false;
+			Set<String> syncAnimationClasses = new LinkedHashSet<>();
 			Set<String> syncParticleClasses = new LinkedHashSet<>();
 
 			{
@@ -341,6 +344,7 @@ public class AsyncParticlesConfig {
 				tick$failPerSecLimit = Mth.clamp(failPerSecLimit, 0, 256);
 				tick$failBehavior = requireNonNullElse(failBehavior, FailBehavior.RAISE_CRASH);
 				tick$suppressCME = suppressCME;
+				tick$syncAnimationClasses = new LinkedHashSet<>(syncAnimationClasses);
 				tick$syncParticleClasses = new LinkedHashSet<>(syncParticleClasses);
 			}
 
@@ -353,6 +357,7 @@ public class AsyncParticlesConfig {
 				failPerSecLimit = tick$failPerSecLimit;
 				failBehavior = tick$failBehavior;
 				suppressCME = tick$suppressCME;
+				syncAnimationClasses.addAll(tick$syncAnimationClasses);
 				syncParticleClasses.addAll(tick$syncParticleClasses);
 			}
 		}

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ClothConfigMenus.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ClothConfigMenus.java
@@ -227,6 +227,13 @@ class ClothConfigMenus {
 				.setSaveConsumer(newValue -> displayConfig.tick.suppressCME = newValue)
 				.build(), originalConfig.tick.suppressCME))
 			.addEntry(modifyOriginal(revertButtonEntryBuilder
+				.startStrList(Component.translatable("config.asyncparticles.tick.syncAnimationClasses"),
+					new ArrayList<>(displayConfig.tick.syncAnimationClasses))
+				.setDefaultValue(new ArrayList<>(defaultConfig.tick.syncAnimationClasses))
+				.setTooltip(Component.translatable("config.asyncparticles.tick.syncAnimationClasses.tooltip"))
+				.setSaveConsumer(newValue -> displayConfig.tick.syncAnimationClasses = new LinkedHashSet<>(newValue))
+				.build(), originalConfig.tick.syncAnimationClasses))
+			.addEntry(modifyOriginal(revertButtonEntryBuilder
 				.startStrList(Component.translatable("config.asyncparticles.tick.syncParticleClasses"),
 					new ArrayList<>(displayConfig.tick.syncParticleClasses))
 				.setDefaultValue(new ArrayList<>(originalConfig.tick.syncParticleClasses))

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/CompatibilityTryItButton.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/CompatibilityTryItButton.java
@@ -193,6 +193,7 @@ public class CompatibilityTryItButton extends Button {
 
 	private static void preserve(ConfigObj modified, MixinConfigObj mixinModified, ConfigObj config, MixinConfigObj mixinConfig) {
 		// preserve modified collections
+		config.tick.syncAnimationClasses = modified.tick.syncAnimationClasses;
 		config.tick.syncParticleClasses = modified.tick.syncParticleClasses;
 		config.particle.particleLimit = modified.particle.particleLimit;
 		config.valkyrienSkies.fixParticleLights = modified.valkyrienSkies.fixParticleLights;

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ConfigHelper.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/config/ConfigHelper.java
@@ -56,6 +56,20 @@ public class ConfigHelper {
 		return rendering$particleCulling;
 	}
 
+	public static List<? extends Class<?>> getSyncAnimationClassesTick() {
+		return tick$syncAnimationClasses
+			.stream()
+			.map(className -> {
+				try {
+					return Class.forName(className);
+				} catch (ClassNotFoundException e) {
+					return null;
+				}
+			})
+			.filter(Objects::nonNull)
+			.toList();
+	}
+
 	public static List<? extends Class<?>> getSyncParticleClassesTick() {
 		return tick$syncParticleClasses
 			.stream()

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/tick/AsyncTickBehavior.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/tick/AsyncTickBehavior.java
@@ -23,7 +23,6 @@ import net.minecraft.client.particle.*;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.level.block.Block;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -357,7 +356,7 @@ public class AsyncTickBehavior {
 		return syncParticleTypes.contains(aClass) || DevRuntimeDebug.isSyncAllParticles();
 	}
 
-	public boolean shouldSyncAnimateTick(Block block) {
+	public boolean shouldSyncAnimateTick(Object block) {
 		return syncAnimationTypes.contains(block.getClass());
 	}
 

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/tick/AsyncTickBehavior.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/core/particle/tick/AsyncTickBehavior.java
@@ -23,6 +23,7 @@ import net.minecraft.client.particle.*;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.block.Block;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -85,6 +86,7 @@ public class AsyncTickBehavior {
 	private boolean reloadLater;
 	private boolean isTailTick;
 
+	private final Set<Class<?>> syncAnimationTypes = new ReferenceOpenHashSet<>();
 	private final Set<Class<?>> syncParticleTypes = new ReferenceOpenHashSet<>();
 	private final Map<ParticleRenderType, Set<Particle>> syncParticles = new Reference2ReferenceOpenHashMap<>();
 	private final Map<ParticleRenderType, Set<TextureSheetParticle>> syncGpuParticles = new Reference2ReferenceOpenHashMap<>();
@@ -305,6 +307,8 @@ public class AsyncTickBehavior {
 			cleanupTaskHelper.waitForCompletion(ExceptionUtil::toThrowDirectly);
 		}
 		cleanupTaskHelper.disposeTasks();
+		syncAnimationTypes.clear();
+		syncAnimationTypes.addAll(ConfigHelper.getSyncAnimationClassesTick());
 		syncParticleTypes.clear();
 		syncParticleTypes.addAll(ConfigHelper.getSyncParticleClassesTick());
 	}
@@ -351,6 +355,10 @@ public class AsyncTickBehavior {
 
 	public boolean shouldSync(Class<? extends Particle> aClass) {
 		return syncParticleTypes.contains(aClass) || DevRuntimeDebug.isSyncAllParticles();
+	}
+
+	public boolean shouldSyncAnimateTick(Block block) {
+		return syncAnimationTypes.contains(block.getClass());
 	}
 
 	public boolean shouldSyncRenderType(Class<? extends ParticleRenderType> aClass) {

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
@@ -6,38 +6,26 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import fun.qu_an.minecraft.asyncparticles.client.core.Diagnostic;
 import fun.qu_an.minecraft.asyncparticles.client.core.Phase;
 import fun.qu_an.minecraft.asyncparticles.client.core.particle.tick.AsyncTickBehavior;
+import fun.qu_an.minecraft.asyncparticles.client.core.particle.tick.LevelBundle;
 import fun.qu_an.minecraft.asyncparticles.client.config.ConfigHelper;
-import fun.qu_an.minecraft.asyncparticles.client.util.GameUtil;
 import fun.qu_an.minecraft.asyncparticles.client.util.ThreadUtil;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
-import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.levelgen.RandomSupport;
 import net.minecraft.world.level.levelgen.SingleThreadedRandomSource;
-import net.minecraft.world.level.storage.WritableLevelData;
+import net.minecraft.world.level.material.FluidState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.function.Supplier;
 
 @Mixin(value = ClientLevel.class, priority = 1100)
-public abstract class MixinClientLevel_AnimateTick extends Level {
-	protected MixinClientLevel_AnimateTick(WritableLevelData writableLevelData, ResourceKey<Level> resourceKey, RegistryAccess registryAccess, Holder<DimensionType> holder, Supplier<ProfilerFiller> supplier, boolean bl, boolean bl2, long l, int i) {
-		super(writableLevelData, resourceKey, registryAccess, holder, supplier, bl, bl2, l, i);
-	}
+public abstract class MixinClientLevel_AnimateTick {
+	@Unique
+	private RandomSource asyncparticles$random;
 
 	@WrapMethod(method = "animateTick")
 	public void asyncparticles_animateTick(int i, int j, int k, Operation<Void> original) {
@@ -59,14 +47,41 @@ public abstract class MixinClientLevel_AnimateTick extends Level {
 		if (ThreadUtil.isOnParticleThread()
 			&& AsyncTickBehavior.getInstance().shouldSyncAnimateTick(block)) {
 			BlockPos immutablePos = pos.immutable();
-			RandomSource mainThreadRandom = new SingleThreadedRandomSource(RandomSupport.generateUniqueSeed());
 			ThreadUtil.runOnClient(() -> {
-				if (Minecraft.getInstance().level == level) {
-					original.call(block, state, level, immutablePos, mainThreadRandom);
+				// We must use strict checks because level, player, and cameraEntity
+				// are not always available at the same time, which can cause crashes.
+				if (LevelBundle.isLevelAvailable()) {
+					original.call(block, state, level, immutablePos, this.asyncparticles$getRandom());
 				}
 			});
 		} else {
 			original.call(block, state, level, pos, random);
 		}
+	}
+
+	@WrapOperation(method = "doAnimateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/material/FluidState;animateTick(Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/util/RandomSource;)V"))
+	private void asyncparticles_shouldSyncAnimateTick(FluidState fluidState, Level level, BlockPos pos, RandomSource random, Operation<Void> original) {
+		if (ThreadUtil.isOnParticleThread()
+			&& AsyncTickBehavior.getInstance().shouldSyncAnimateTick(fluidState.getType())) {
+			BlockPos immutablePos = pos.immutable();
+			ThreadUtil.runOnClient(() -> {
+				if (LevelBundle.isLevelAvailable()) {
+					original.call(fluidState, level, immutablePos, this.asyncparticles$getRandom());
+				}
+			});
+		} else {
+			original.call(fluidState, level, pos, random);
+		}
+	}
+
+	@Unique
+	private RandomSource asyncparticles$getRandom() {
+		// Reuse a main thread only random source to avoid repeated allocation,
+		// since doAnimateTick is invoked 1664 times per tick, and we cannot ignore the worst cases.
+		RandomSource random = this.asyncparticles$random;
+		if (random != null) {
+			return random;
+		}
+		return this.asyncparticles$random = new SingleThreadedRandomSource(RandomSupport.generateUniqueSeed());
 	}
 }

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
@@ -8,7 +8,10 @@ import fun.qu_an.minecraft.asyncparticles.client.core.Phase;
 import fun.qu_an.minecraft.asyncparticles.client.core.particle.tick.AsyncTickBehavior;
 import fun.qu_an.minecraft.asyncparticles.client.config.ConfigHelper;
 import fun.qu_an.minecraft.asyncparticles.client.util.GameUtil;
+import fun.qu_an.minecraft.asyncparticles.client.util.ThreadUtil;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.ResourceKey;
@@ -16,6 +19,8 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.levelgen.RandomSupport;
 import net.minecraft.world.level.levelgen.SingleThreadedRandomSource;
@@ -47,5 +52,21 @@ public abstract class MixinClientLevel_AnimateTick extends Level {
 	@WrapOperation(method = "animateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/util/RandomSource;create()Lnet/minecraft/util/RandomSource;"))
 	private RandomSource redirectRandomSource(Operation<RandomSource> original) {
 		return new SingleThreadedRandomSource(RandomSupport.generateUniqueSeed());
+	}
+
+	@WrapOperation(method = "doAnimateTick", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/Block;animateTick(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/util/RandomSource;)V"))
+	private void asyncparticles_shouldSyncAnimateTick(Block block, BlockState state, Level level, BlockPos pos, RandomSource random, Operation<Void> original) {
+		if (ThreadUtil.isOnParticleThread()
+			&& AsyncTickBehavior.getInstance().shouldSyncAnimateTick(block)) {
+			BlockPos immutablePos = pos.immutable();
+			RandomSource mainThreadRandom = new SingleThreadedRandomSource(RandomSupport.generateUniqueSeed());
+			ThreadUtil.runOnClient(() -> {
+				if (Minecraft.getInstance().level == level) {
+					original.call(block, state, level, immutablePos, mainThreadRandom);
+				}
+			});
+		} else {
+			original.call(block, state, level, pos, random);
+		}
 	}
 }

--- a/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
+++ b/common/src/main/java/fun/qu_an/minecraft/asyncparticles/client/mixin/core/animate_tick/MixinClientLevel_AnimateTick.java
@@ -47,7 +47,7 @@ public abstract class MixinClientLevel_AnimateTick {
 		if (ThreadUtil.isOnParticleThread()
 			&& AsyncTickBehavior.getInstance().shouldSyncAnimateTick(block)) {
 			BlockPos immutablePos = pos.immutable();
-			ThreadUtil.runOnClient(() -> {
+			ThreadUtil.enqueueClientTask(() -> {
 				// We must use strict checks because level, player, and cameraEntity
 				// are not always available at the same time, which can cause crashes.
 				if (LevelBundle.isLevelAvailable()) {
@@ -64,7 +64,7 @@ public abstract class MixinClientLevel_AnimateTick {
 		if (ThreadUtil.isOnParticleThread()
 			&& AsyncTickBehavior.getInstance().shouldSyncAnimateTick(fluidState.getType())) {
 			BlockPos immutablePos = pos.immutable();
-			ThreadUtil.runOnClient(() -> {
+			ThreadUtil.enqueueClientTask(() -> {
 				if (LevelBundle.isLevelAvailable()) {
 					original.call(fluidState, level, immutablePos, this.asyncparticles$getRandom());
 				}

--- a/common/src/main/resources/assets/asyncparticles/lang/en_us.json
+++ b/common/src/main/resources/assets/asyncparticles/lang/en_us.json
@@ -33,6 +33,8 @@
   "config.asyncparticles.tick.failBehavior.tooltip": "Action to take when failure rate\nexceeds the limit.",
   "config.asyncparticles.tick.suppressCME": "Suppress CME",
   "config.asyncparticles.tick.suppressCME.tooltip": "Ignore 'ConcurrentModificationException'\nwhile under 'Fail Per Second Limit'.",
+  "config.asyncparticles.tick.syncAnimationClasses": "Animation Classes for Synchronous Tick",
+  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "Animation classes that should be ticked synchronously.",
   "config.asyncparticles.tick.syncParticleClasses": "Particle Classes for Synchronous Tick",
   "config.asyncparticles.tick.syncParticleClasses.tooltip": "Particle classes that should be ticked synchronously.",
   "config.asyncparticles.category.rendering": "Rendering",

--- a/common/src/main/resources/assets/asyncparticles/lang/en_us.json
+++ b/common/src/main/resources/assets/asyncparticles/lang/en_us.json
@@ -34,7 +34,7 @@
   "config.asyncparticles.tick.suppressCME": "Suppress CME",
   "config.asyncparticles.tick.suppressCME.tooltip": "Ignore 'ConcurrentModificationException'\nwhile under 'Fail Per Second Limit'.",
   "config.asyncparticles.tick.syncAnimationClasses": "Animation Classes for Synchronous Tick",
-  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "Animation classes that should be ticked synchronously.",
+  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "Animation classes that should be ticked synchronously (subclasses of Block or Fluid).",
   "config.asyncparticles.tick.syncParticleClasses": "Particle Classes for Synchronous Tick",
   "config.asyncparticles.tick.syncParticleClasses.tooltip": "Particle classes that should be ticked synchronously.",
   "config.asyncparticles.category.rendering": "Rendering",

--- a/common/src/main/resources/assets/asyncparticles/lang/zh_cn.json
+++ b/common/src/main/resources/assets/asyncparticles/lang/zh_cn.json
@@ -33,6 +33,8 @@
   "config.asyncparticles.tick.failBehavior.tooltip": "当 Tick 异常频率超过上限时执行的操作。",
   "config.asyncparticles.tick.suppressCME": "忽略并发修改异常",
   "config.asyncparticles.tick.suppressCME.tooltip": "在未超过“每秒 Tick 异常上限”时忽略\nConcurrentModificationException 。",
+  "config.asyncparticles.tick.syncAnimationClasses": "同步 Tick 的动画类",
+  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "需要同步执行 Tick 任务的动画类。",
   "config.asyncparticles.tick.syncParticleClasses": "同步 Tick 的粒子类",
   "config.asyncparticles.tick.syncParticleClasses.tooltip": "需要同步执行 Tick 任务的粒子类。",
   "config.asyncparticles.category.rendering": "渲染",

--- a/common/src/main/resources/assets/asyncparticles/lang/zh_cn.json
+++ b/common/src/main/resources/assets/asyncparticles/lang/zh_cn.json
@@ -34,7 +34,7 @@
   "config.asyncparticles.tick.suppressCME": "忽略并发修改异常",
   "config.asyncparticles.tick.suppressCME.tooltip": "在未超过“每秒 Tick 异常上限”时忽略\nConcurrentModificationException 。",
   "config.asyncparticles.tick.syncAnimationClasses": "同步 Tick 的动画类",
-  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "需要同步执行 Tick 任务的动画类。",
+  "config.asyncparticles.tick.syncAnimationClasses.tooltip": "需要同步执行 Tick 任务的动画类（Block 或 Fluid 的子类）。",
   "config.asyncparticles.tick.syncParticleClasses": "同步 Tick 的粒子类",
   "config.asyncparticles.tick.syncParticleClasses.tooltip": "需要同步执行 Tick 任务的粒子类。",
   "config.asyncparticles.category.rendering": "渲染",


### PR DESCRIPTION
你好，这个 PR 主要做了以下修改：
> 1. 更新了 `.gitignore` 文件，新增 Git 忽略 `**/bin/` 系列目录文件，它们是构建缓存，这可以防止它们被意外地提交到 Git 仓库中；
> 2. 新增了 `同步 Tick 的动画类` 功能，类似于原有的 `同步 Tick 的粒子类` 功能，会将符合列表中的动画类交回主渲染线程，其他保持不变，默认值为空，这可以方便用户根据自身的不同模组环境，自行配置该项目，使其能够成为因为其他模组造成的兼容性问题，出现不能异步的动画刻就只能关闭所有异步动画刻的更优解决方案。

功能测试已通过：
> - 同时安装 AsyncParticles、Blueprint、Neapolitan 这3个模组。因 Neapolitan 会通过 Mixin 修改原版滴水石锥的 `animateTick` 方法，并导致 AsyncParticles 不能再安全地异步原版滴水石锥的动画。
> - 在新增的 `同步 Tick 的动画类` 功能中，新增条目 `net.minecraft.world.level.block.PointedDripstoneBlock` ，重启游戏后，不再提示错误，且 Neapolitan 向原版滴水石锥添加的新功能也正常运行。